### PR TITLE
 Exercicio de promises - Greice Pereira

### DIFF
--- a/exercicios/para-casa/email-correto.js
+++ b/exercicios/para-casa/email-correto.js
@@ -1,0 +1,72 @@
+
+/*
+ [ ] Consumir a promise  de envio de email com sucesso.
+
+Regras de negocio:
+
+1. Antes de enviar o email precisa imprimir no terminal uma mensagem que o email está
+ sendo enviado
+
+2. Ao consumir a promise é necessário imprimir o seu resultado no terminal,
+ seguindo o exemplo abaixo( Não precisa conter a mesma formatação ex: tracos,
+     indentação, quebra de linhas etc...)
+
+console:
+```bash
+  tentando enviar email...
+  Para: beatriz@email.com
+  ---------------------------------------
+  Para conseguir realizar esse exercicio será necessário combinar todos
+   os conhecimentos adquiridos em aula... 
+  email enviado com sucesso.
+```
+*/
+
+const verificarEmail =(email) =>{
+return new Promise((resolve, reject)=>{
+    setTimeout(()=>{
+     if(!email){
+        return reject(" Verificando email. ")
+     } 
+     return resolve({
+        email
+     })  
+    },2000)
+})
+
+
+
+}
+const verficarMensangem = (mensagem) => {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        if (mensagem === "" || mensagem === undefined) {
+          return reject("campo mensagem não pode esta vazio")
+        }
+        return resolve({
+          mensagem
+          
+        })
+      },1000)
+    })
+  
+  }
+
+  const imprimirDados = (email, mensagem) => {
+    verificarEmail("greicepereira2020@gmail.com").then((destinataria) => {
+        console.log("\nO email está sendo enviado...")
+        verficarMensangem("Ola mundo,e assim que faz uma promises.").then((usuaria) => {
+          console.log(`
+          Para: ${destinataria.email}
+          -----------------------------------------
+          Mensagem: ${usuaria.mensagem}
+          `)
+          console.log("Email enviado com sucesso.")
+        })
+        
+      },3000)
+      .catch((err) => {
+        console.error(err);
+      });
+  }
+  imprimirDados()

--- a/exercicios/para-casa/email-erro.js
+++ b/exercicios/para-casa/email-erro.js
@@ -1,0 +1,59 @@
+
+/*
+ [ ] Consumir a promise de envio de email com erro.
+
+console:
+```bash
+  tentando enviar email...
+
+  falha ao enviar o email.
+*/
+
+const verificarEmail = (email) => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (!email) {
+        return reject();
+      }
+      return resolve({
+        email
+      });
+    }, 1000);
+  })
+  .catch(() => {
+    console.log("\nO email esta incorreto");
+  });
+};
+
+const verficarMensangem = (mensagem) => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (!mensagem) {
+        return reject("O campo mensagem não pode estar vazio");
+      }
+      return resolve({
+        mensagem
+      });
+    }, 1000);
+  });
+};
+
+const imprimirDados = (email, mensagem) => {
+  verificarEmail("greicepereira2020@gmail.com").then((destinataria) => {
+    console.log("\nTentando enviar email...");
+    verficarMensangem("")
+      .then((usuaria) => {
+        console.log(`
+          Para: ${destinataria.email}
+          -----------------------------------------
+          Mensagem: ${usuaria.mensagem}
+          `);
+        console.log("Email enviado com sucesso.");
+      })
+      .catch(() => {
+        console.log("\nFalha ao enviar o email.");
+      });
+  }, 3000);
+};
+
+imprimirDados();

--- a/exercicios/para-casa/email-promises.js
+++ b/exercicios/para-casa/email-promises.js
@@ -1,0 +1,57 @@
+
+
+/* 
+[ ] Criar uma promise que simule um envio de email ela precisa ter como parametro: 
+  - o email da destinataria
+  - mensagem que será enviada.
+
+ Regras de negocio:
+  a. Se o email for vazio a retornar um erro
+*/
+
+const verificarEmail = (email) => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (!email) {
+        return reject(" O email esta incorreto ")
+      }
+      return resolve({
+        email
+        
+      })
+    }, 1000)
+  }
+  )
+
+}
+
+const verficarMensangem = (mensagem) => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (mensagem === "" || mensagem === undefined) {
+        return reject("campo mensagem não pode esta vazio")
+      }
+      return resolve({
+        mensagem
+      })
+    },1000)
+  })
+
+}
+
+const imprimirDados = (email, mensagem) => {
+  verificarEmail("").then((destinataria) => {
+      console.log("email verificado")
+      verficarMensangem(" exercico de promises").then((usuaria) => {
+        console.log(`
+        email:${destinataria.email}
+        mensagem:${usuaria.mensagem}
+        `)
+
+      })
+    },3000)
+    .catch((err) => {
+      console.error(err);
+    });
+}
+imprimirDados()


### PR DESCRIPTION
  Exercicio de promise e callback

  Foram realizados exercicios para imprimir email no terminal, usando promises, callback  para verificar 
 mensagem e  email. 
 O catch foi ultilizado para tratar e  apresentar a mensagem de erro  quando a mensagem estiver vazia ou email  estiver incorreto.
